### PR TITLE
exclude page title & subtitle from TOC

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -10,6 +10,7 @@ In order to get the most out of a workshop, hackathon or sprint, it’s importan
 
 .. contents:: In this guide
    :class: bs-sidenav affix
+   :local: 
 
 Defining goals
 ==============


### PR DESCRIPTION
rst contents directive takes a :local flag that generates contents only from the tree depth where the contents directive is placed http://docutils.sourceforge.net/docs/ref/rst/directives.html
