### PR TITLE
Add notes about dependencies to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,19 +7,24 @@ This document is licensed `CC BY <a href="http://creativecommons.org/licenses/by
 For Developers
 ======================
 
-To install the project, fork this repository and clone it to your computer.  Get dependencies
-by typing the following two commands::
+To install the project, fork this repository and clone it to your computer.
+
+If you don't have it installed, you may need to get pypi-install by running (on Debian and its derivatives)::
+
+   sudo apt-get install python-stdeb
+
+Then, get the dependencies for the project by typing the following two commands (on Debian and its derivatives)::
 
    sudo apt-get install python-sphinx
    sudo pypi-install sphinx-bootstrap-theme
 
-You may need to install pypi-install in order to run the above commands.  To install pypi-install, type::
+You may also need to install GNU make, which is usually available on Debian via one of the following::
 
-   sudo apt-get install python-stdeb
+   sudo apt-get install build-essential # Also installs a bunch of compilers, useful for other projects too
+   sudo apt-get install make # Installs only the base utility, less useful in a broad sense
 
 Once you've installed the dependencies, you can render the project by typing::
 
    make html
 
 You will find the rendered pages in *_build/html*.  A good place to start looking around is *index.html*.
-


### PR DESCRIPTION
The order of the dependency resolution confused me, so I'm sure it will
be confusing to others. Also added note about GNU make, and about the
nature of apt-get being a Debian thing.

Consider adding Fedora-type install instructions?
