### PR TITLE
Migrate hosting to Firebase Static Hosting

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "opensource-events-com"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _build/*
 build
+.firebase

--- a/README.rst
+++ b/README.rst
@@ -28,3 +28,12 @@ Once you've installed the dependencies, you can render the project by typing::
    make html
 
 You will find the rendered pages in *_build/html*.  A good place to start looking around is *index.html*.
+
+
+For Publisher aka Deployer
+==========================
+
+This repo contains the **source** of the website.
+
+We use Firebase Static Hosting to host the website. To deploy a new version, run
+`./deploy.sh`. It will guide you through the process.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-set -e
-set -x
+set -eou pipefail
 
+if ! which firebase 2>&1 > /dev/null ; then
+    echo 'You need to install the Firebase CLI tools to use this script.'
+    echo 'See: https://firebase.google.com/docs/cli'
+    exit 1
+fi
+
+echo 'Building the Sphinx site...'
 make html
-rsync -avzP --delete "$PWD"/_build/html/. paulproteus_ohusergroups@ssh.phx.nearlyfreespeech.net:.
 
+echo 'Publishing the site to Firebase hosting...'
+firebase deploy
+
+echo 'Done.'

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,10 @@
+{
+  "hosting": {
+    "public": "_build/html",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }
+}


### PR DESCRIPTION
I'm going to merge this now; making this a pull request for clarity for the future.

For "simplicity" (nothing is ever exactly simple), I've decided to migrate the hosting portion of this site to Google Firebase Static Hosting. I've updated README accordingly.

Action required: @shaunagm , you specifically need to click a link that Google sent you so you can be added to the opensource-events-com Firebase project. Once you are in it, I consider you the owner; feel free to ask me for advice, but it's yours, change the site if you want, etc. I'll aim to keep it online, which should happen automatically even if I do nothing; I'll also keep renewing the domain for five years or so, and then we can think again.

My request is that you try doing a deploy on your own, and try it, and make sure that you understand what I've done, and make sure the docs are something you'll understand if you ever need to fix a typo or something later.

For what it's worth, I picked Google Firebase Static Hosting because:

- It's easy to set up HTTPS.

- If we keep the site using Sphinx, then Sphinx has a concept of the site's source code (which is in GitHub at https://github.com/openhatch/in-person-event-handbook ) as well as concept of the *built* site (which is the HTML that people see). I think it's straightforward to use GitHub for only one of these (source code), and to use a different thing for the site hosting, since otherwise it's too easy to get confused and think that the GitHub source code is also the place that stores the live site.

- Right now, due to the way I migrated this site, there is another GitHub repository that contains the built site, and this is confusing IMHO: https://github.com/openhatch/opensource-events.com . I'll probably delete that once the site works properly in Firebase.

- Firebase Static Hosting is free of charge (up to 10GB/mo of transfer, which seems fine to me), so it's equally good to GitHub Pages in that regard.

In the process, I have temporarily replaced the site with a HTTPS error page; this should self-heal within approx 24 hours.

I'm writing this in a hurry to get it done, so if my tone seems off, please know that I am writing this in the interest of being informative; if some of it is redundant with things you already know, no condescension meant.

You can add this info to the README if you want!

Let me know when you try the deploy.sh file!

Best!,

Asheesh.